### PR TITLE
Patch burp.js

### DIFF
--- a/burp.js
+++ b/burp.js
@@ -46,7 +46,9 @@ function loadMessages(filename, includePingPong) {
         break;
       }
       while (zero == -1) {
-        pages.append(Buffer.alloc(PAGE_SIZE));
+        // replaced to try to patch it
+        //pages.append(Buffer.alloc(PAGE_SIZE));
+        pages.push(Buffer.alloc(PAGE_SIZE));
         bytes = fs.readSync(fd, pages[pages.length - 1], 0, PAGE_SIZE);
         totBytes += bytes;
         everything = Buffer.concat(pages);
@@ -72,6 +74,14 @@ function loadMessages(filename, includePingPong) {
     }
     pages = [pages[pages.length - 1], pages[0]];
   }
+
+
+  // Dirty clean-up of msgStrings -- only allow ["{\\"msg' or "a[\"{\\\"msg" strings
+  // Avoids issues with weird ass POST requests etc. that also ended up in there
+  msgStrings = msgStrings.filter((msg) => 
+    msg.startsWith('["{\\"msg') || msg.startsWith('a[\"{\\\"msg')
+  );
+
   let results = msgStrings.map((m) => DDPMessage.unwrap(m));
   if (!includePingPong) {
     results = results.filter((m) => m.msg != 'ping' && m.msg != 'pong');


### PR DESCRIPTION
When using your tool, I ran into some issues. I've managed to find a dirty patch that resolved these issues for me. There were two problems, as listed below:

# Issue 1

## Description
When running `node ./ehf.js confusertargets -b ~/Documents/Projects/project.burp > confuser.json`, I got the error message 
```
TypeError: pages.append is not a function
    at loadMessages (/[...]/eighthundredfeet/burp.js:49:15)
```

## Patch
I use pages.push() instead of pages.append(). 

# Issue 2
After applying that patch, I get 
```
SyntaxError: Unexpected token 'P', "POST /sock"... is not valid JSON
    at JSON.parse (<anonymous>)
    at EJSON.parse (/[...]/eighthundredfeet/node_modules/ejson/index.js:933:35)
    at DDPMessage.unwrap (/[...]/eighthundredfeet/ddp.js:47:22)
    at /[...]/eighthundredfeet/burp.js:77:50
    at Array.map (<anonymous>)
```
The issue seems to be that `msgStrings` also includes messages like `"POST /sockjs/[redacted]/xhr_send HTTP/2\r\nHost: [...]`, which then yields teh JSON parse error.

## Patch
I filter any  non-websocket message before applying the map function:
```
  msgStrings = msgStrings.filter((msg) => 
    msg.startsWith('["{\\"msg') || msg.startsWith('a[\"{\\\"msg')
  );
```

# Note
I am not an experienced developer and my patches are really just quick and dirty solutions to help me use your tool for my project. I don't claim that these are fool proof or elegant solutions, but hopefully they provide some inspiration 😄 

Thanks for your work!